### PR TITLE
Add context to and return error from Parse methods

### DIFF
--- a/bash/binding_test.go
+++ b/bash/binding_test.go
@@ -1,6 +1,7 @@
 package bash_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("echo 1"), bash.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("echo 1"), bash.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (command name: (command_name (word)) argument: (word)))",
 		n.String(),

--- a/bindings.go
+++ b/bindings.go
@@ -90,8 +90,6 @@ func (p *Parser) Parse(ctx context.Context, oldTree *Tree, content []byte) (*Tre
 		case <-parseComplete:
 			return
 		}
-
-		fmt.Println("goroutine exiting")
 	}()
 
 	input := C.CBytes(content)

--- a/bindings.go
+++ b/bindings.go
@@ -80,8 +80,7 @@ func (p *Parser) Parse(ctx context.Context, oldTree *Tree, content []byte) (*Tre
 		BaseTree = oldTree.c
 	}
 
-	parseComplete := make(chan struct{}, 1)
-	defer close(parseComplete)
+	parseComplete := make(chan struct{})
 
 	go func() {
 		select {
@@ -94,7 +93,7 @@ func (p *Parser) Parse(ctx context.Context, oldTree *Tree, content []byte) (*Tre
 
 	input := C.CBytes(content)
 	BaseTree = C.ts_parser_parse_string(p.c, BaseTree, (*C.char)(input), C.uint32_t(len(content)))
-	parseComplete <- struct{}{}
+	close(parseComplete)
 	C.free(input)
 
 	return p.convertTSTree(ctx, BaseTree)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -2,6 +2,7 @@ package sitter
 
 import (
 	"bytes"
+	"context"
 	"runtime"
 	"strconv"
 	"strings"
@@ -16,7 +17,8 @@ import (
 func TestRootNode(t *testing.T) {
 	assert := assert.New(t)
 
-	n := Parse([]byte("1 + 2"), getTestGrammar())
+	n, err := Parse(context.Background(), []byte("1 + 2"), getTestGrammar())
+	assert.NoError(err)
 
 	assert.Equal(uint32(0), n.StartByte())
 	assert.Equal(uint32(5), n.EndByte())
@@ -61,7 +63,8 @@ func TestTree(t *testing.T) {
 
 	parser.Debug()
 	parser.SetLanguage(getTestGrammar())
-	tree := parser.Parse(nil, []byte("1 + 2"))
+	tree, err := parser.Parse(context.Background(), nil, []byte("1 + 2"))
+	assert.NoError(err)
 	n := tree.RootNode()
 
 	assert.Equal(uint32(0), n.StartByte())
@@ -94,7 +97,8 @@ func TestTree(t *testing.T) {
 	assert.False(n.Child(0).Child(0).HasChanges()) // left side of the sum didn't change
 	assert.True(n.Child(0).Child(2).HasChanges())
 
-	tree2 := parser.Parse(tree, newText)
+	tree2, err := parser.Parse(context.Background(), tree, newText)
+	assert.NoError(err)
 	n = tree2.RootNode()
 	assert.Equal("(expression (sum left: (expression (number)) right: (expression (expression (sum left: (expression (number)) right: (expression (number)))))))", n.String())
 }
@@ -118,7 +122,8 @@ func TestGC(t *testing.T) {
 	parser := NewParser()
 
 	parser.SetLanguage(getTestGrammar())
-	tree := parser.Parse(nil, []byte("1 + 2"))
+	tree, err := parser.Parse(context.Background(), nil, []byte("1 + 2"))
+	assert.NoError(err)
 	n := tree.RootNode()
 
 	r := isNamedWithGC(n)
@@ -152,10 +157,45 @@ func TestOperationLimitParsing(t *testing.T) {
 		items = append(items, strconv.Itoa(i))
 	}
 	code := strings.Join(items, " + ")
-	tree := parser.Parse(nil, []byte(code))
-	root := tree.RootNode()
+	tree, err := parser.Parse(context.Background(), nil, []byte(code))
+	assert.EqualError(err, ErrOperationLimit.Error())
+	assert.Nil(tree)
+}
 
-	assert.Nil(root)
+func TestContextCancellationParsing(t *testing.T) {
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	parser := NewParser()
+	parser.SetLanguage(getTestGrammar())
+	items := []string{}
+	for i := 0; i < 100; i++ {
+		items = append(items, strconv.Itoa(i))
+	}
+	code := strings.Join(items, " + ")
+
+	started := make(chan bool)
+	done := make(chan bool)
+
+	var tree *Tree
+	var err error
+	go func() {
+		defer close(started)
+		defer close(done)
+		start := time.Now()
+		started <- true
+		tree, err = parser.Parse(ctx, nil, []byte(code))
+		t.Logf("parsing complete after %s, error: %+v\n", time.Since(start), err)
+		done <- true
+	}()
+
+	<-started
+	cancel()
+	<-done
+
+	assert.EqualError(err, context.Canceled.Error())
+	assert.Nil(tree)
 }
 
 func TestIncludedRanges(t *testing.T) {
@@ -166,7 +206,8 @@ func TestIncludedRanges(t *testing.T) {
 
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
-	mainTree := parser.Parse(nil, []byte(code))
+	mainTree, err := parser.Parse(context.Background(), nil, []byte(code))
+	assert.NoError(err)
 	assert.Equal(
 		"(expression (sum left: (expression (number)) right: (expression (number))) (comment))",
 		mainTree.RootNode().String(),
@@ -185,8 +226,9 @@ func TestIncludedRanges(t *testing.T) {
 	}
 
 	parser.SetIncludedRanges([]Range{commentRange})
-	commentTree := parser.Parse(nil, []byte(code))
+	commentTree, err := parser.Parse(context.Background(), nil, []byte(code))
 
+	assert.NoError(err)
 	assert.Equal(
 		"(expression (sum left: (expression (number)) right: (expression (number))))",
 		commentTree.RootNode().String(),
@@ -198,7 +240,8 @@ func TestSameNode(t *testing.T) {
 
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
-	tree := parser.Parse(nil, []byte("1 + 2"))
+	tree, err := parser.Parse(context.Background(), nil, []byte("1 + 2"))
+	assert.NoError(err)
 
 	n1 := tree.RootNode()
 	n2 := tree.RootNode()
@@ -228,7 +271,8 @@ func TestQuery(t *testing.T) {
 	// test match only
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
-	tree := parser.Parse(nil, []byte(js))
+	tree, err := parser.Parse(context.Background(), nil, []byte(js))
+	assert.NoError(t, err)
 	root := tree.RootNode()
 
 	q, err := NewQuery([]byte("(sum) (number)"), getTestGrammar())
@@ -255,7 +299,8 @@ func testCaptures(t *testing.T, body, sq string, expected []string) {
 
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
-	tree := parser.Parse(nil, []byte(body))
+	tree, err := parser.Parse(context.Background(), nil, []byte(body))
+	assert.NoError(err)
 	root := tree.RootNode()
 
 	q, err := NewQuery([]byte(sq), getTestGrammar())
@@ -310,7 +355,9 @@ func TestParserLifetime(t *testing.T) {
 				// create some memory/CPU pressure
 				data = append(data, bytes.Repeat([]byte(" "), 1024*1024)...)
 
-				root := p.Parse(nil, data).RootNode()
+				tree, err := p.Parse(context.Background(), nil, data)
+				assert.NoError(t, err)
+				root := tree.RootNode()
 				// make sure we have no references to the Parser
 				p = nil
 				// must be a separate function, and it shouldn't accept the parser, only the Tree
@@ -326,7 +373,8 @@ func TestTreeCursor(t *testing.T) {
 
 	input := []byte(`1 + 2`)
 
-	root := Parse(input, getTestGrammar())
+	root, err := Parse(context.Background(), input, getTestGrammar())
+	assert.NoError(err)
 	c := NewTreeCursor(root)
 
 	assert.True(c.CurrentNode() == root)
@@ -363,11 +411,12 @@ func TestTreeCursor(t *testing.T) {
 }
 
 func TestLeakParse(t *testing.T) {
+	ctx := context.Background()
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
 
 	for i := 0; i < 100000; i++ {
-		_ = parser.Parse(nil, []byte("1 + 2"))
+		_, _ = parser.Parse(ctx, nil, []byte("1 + 2"))
 	}
 
 	runtime.GC()
@@ -380,11 +429,13 @@ func TestLeakParse(t *testing.T) {
 }
 
 func TestLeakRootNode(t *testing.T) {
+	ctx := context.Background()
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
 
 	for i := 0; i < 100000; i++ {
-		tree := parser.Parse(nil, []byte("1 + 2"))
+		tree, err := parser.Parse(ctx, nil, []byte("1 + 2"))
+		assert.NoError(t, err)
 		_ = tree.RootNode()
 	}
 
@@ -410,7 +461,8 @@ func TestParseInput(t *testing.T) {
 			return nil
 		},
 	}
-	tree := parser.ParseInput(nil, input)
+	tree, err := parser.ParseInput(context.Background(), nil, input)
+	assert.NoError(err)
 	n := tree.RootNode()
 	assert.Equal("(ERROR)", n.String())
 
@@ -426,7 +478,8 @@ func TestParseInput(t *testing.T) {
 
 		return inputData
 	}
-	tree = parser.ParseInput(nil, input)
+	tree, err = parser.ParseInput(context.Background(), nil, input)
+	assert.NoError(err)
 	n = tree.RootNode()
 	assert.Equal("(expression (sum left: (expression (number)) right: (expression (number))))", n.String())
 	assert.Equal(readTimes, 1)
@@ -444,13 +497,14 @@ func TestParseInput(t *testing.T) {
 
 		return inputData[offset:end]
 	}
-	tree = parser.ParseInput(nil, input)
+	tree, err = parser.ParseInput(context.Background(), nil, input)
 	n = tree.RootNode()
 	assert.Equal("(expression (sum left: (expression (number)) right: (expression (number))))", n.String())
 	assert.Equal(readTimes, 4)
 }
 
 func TestLeakParseInput(t *testing.T) {
+	ctx := context.Background()
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
 
@@ -467,7 +521,7 @@ func TestLeakParseInput(t *testing.T) {
 	}
 
 	for i := 0; i < 100000; i++ {
-		_ = parser.ParseInput(nil, input)
+		_, _ = parser.ParseInput(ctx, nil, input)
 	}
 
 	runtime.GC()
@@ -480,6 +534,7 @@ func TestLeakParseInput(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
+	ctx := context.Background()
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
 	inputData := []byte("1 + 2")
@@ -487,11 +542,12 @@ func BenchmarkParse(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = parser.Parse(nil, inputData)
+		_, _ = parser.Parse(ctx, nil, inputData)
 	}
 }
 
 func BenchmarkParseInput(b *testing.B) {
+	ctx := context.Background()
 	parser := NewParser()
 	parser.SetLanguage(getTestGrammar())
 
@@ -510,6 +566,6 @@ func BenchmarkParseInput(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_ = parser.ParseInput(nil, input)
+		_, _ = parser.ParseInput(ctx, nil, input)
 	}
 }

--- a/c/binding_test.go
+++ b/c/binding_test.go
@@ -1,6 +1,7 @@
 package c_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("int a = 2;"), c.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("int a = 2;"), c.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(translation_unit (declaration type: (primitive_type) declarator: (init_declarator declarator: (identifier) value: (number_literal))))",
 		n.String(),

--- a/cpp/binding_test.go
+++ b/cpp/binding_test.go
@@ -1,6 +1,7 @@
 package cpp_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("int a = 2;"), cpp.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("int a = 2;"), cpp.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(translation_unit (declaration type: (primitive_type) declarator: (init_declarator declarator: (identifier) value: (number_literal))))",
 		n.String(),

--- a/csharp/binding_test.go
+++ b/csharp/binding_test.go
@@ -1,6 +1,7 @@
 package csharp_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("using static System.Math;"), csharp.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("using static System.Math;"), csharp.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(compilation_unit (using_directive (qualified_name (identifier) (identifier))))",
 		n.String(),

--- a/css/binding_test.go
+++ b/css/binding_test.go
@@ -1,6 +1,7 @@
 package css_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`p { color: red; }`), css.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`p { color: red; }`), css.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(stylesheet (rule_set (selectors (tag_name)) (block (declaration (property_name) (plain_value)))))",
 		n.String(),

--- a/dockerfile/binding_test.go
+++ b/dockerfile/binding_test.go
@@ -1,6 +1,7 @@
 package dockerfile_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("FROM microsoft/nanoserver"), dockerfile.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("FROM microsoft/nanoserver"), dockerfile.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(source_file (from_instruction (image_spec name: (image_name))) (MISSING \"\n\"))",
 		n.String(),

--- a/elm/binding_test.go
+++ b/elm/binding_test.go
@@ -1,6 +1,7 @@
 package elm_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("import Html exposing (text)"), elm.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("import Html exposing (text)"), elm.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(file (import_clause (import) moduleName: (upper_case_qid (upper_case_identifier)) exposing: (exposing_list (exposing) (exposed_value (lower_case_identifier)))))",
 		n.String(),

--- a/golang/binding_test.go
+++ b/golang/binding_test.go
@@ -1,6 +1,7 @@
 package golang_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("package main"), golang.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("package main"), golang.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(source_file (package_clause (package_identifier)))",
 		n.String(),

--- a/hcl/binding_test.go
+++ b/hcl/binding_test.go
@@ -1,6 +1,7 @@
 package hcl_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`image_id = "abc123"`), hcl.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`image_id = "abc123"`), hcl.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(source_file (body (attribute (identifier) (expression (expr_term (template_expr (quoted_template)))) (MISSING \"\n\"))))",
 		n.String(),

--- a/html/binding_test.go
+++ b/html/binding_test.go
@@ -1,6 +1,7 @@
 package html_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`<HTML><BODY><P>Hello World</P></BODY></HTML>`), html.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`<HTML><BODY><P>Hello World</P></BODY></HTML>`), html.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(fragment (element (start_tag (tag_name)) (element (start_tag (tag_name)) (element (start_tag (tag_name)) (text) (end_tag (tag_name))) (end_tag (tag_name))) (end_tag (tag_name))))",
 		n.String(),

--- a/java/binding_test.go
+++ b/java/binding_test.go
@@ -1,6 +1,7 @@
 package java_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("import java.io.*;"), java.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("import java.io.*;"), java.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (import_declaration (scoped_identifier scope: (identifier) name: (identifier)) (asterisk)))",
 		n.String(),

--- a/javascript/binding_test.go
+++ b/javascript/binding_test.go
@@ -1,6 +1,7 @@
 package javascript_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("let a = 1"), javascript.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("let a = 1"), javascript.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (lexical_declaration (variable_declarator name: (identifier) value: (number))))",
 		n.String(),

--- a/lua/binding_test.go
+++ b/lua/binding_test.go
@@ -1,6 +1,7 @@
 package lua_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`print("Hello World!")`), lua.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`print("Hello World!")`), lua.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (function_call prefix: (identifier) (function_call_paren) args: (function_arguments (string)) (function_call_paren)))",
 		n.String(),

--- a/ocaml/binding_test.go
+++ b/ocaml/binding_test.go
@@ -1,6 +1,7 @@
 package ocaml_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`print_endline "Hello World!"`), ocaml.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`print_endline "Hello World!"`), ocaml.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(compilation_unit (expression_item (application_expression function: (value_path (value_name)) argument: (string (string_content)))))",
 		n.String(),

--- a/php/binding_test.go
+++ b/php/binding_test.go
@@ -1,6 +1,7 @@
 package php_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("<?php print(1);"), php.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("<?php print(1);"), php.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (php_tag) (expression_statement (print_intrinsic (parenthesized_expression (integer)))))",
 		n.String(),

--- a/protobuf/binding_test.go
+++ b/protobuf/binding_test.go
@@ -1,6 +1,7 @@
 package protobuf_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -19,7 +20,8 @@ message Thing {
   repeated uint32 scores = 2;
 }
 `
-	n := sitter.Parse([]byte(code), protobuf.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(code), protobuf.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(source_file (syntax) (message (message_name (identifier)) (message_body (field (type) (identifier) (field_number (int_lit (decimal_lit)))) (field (type) (identifier) (field_number (int_lit (decimal_lit)))))))",
 		n.String(),

--- a/python/binding_test.go
+++ b/python/binding_test.go
@@ -1,6 +1,7 @@
 package python_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("print(1)"), python.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("print(1)"), python.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(module (expression_statement (call function: (identifier) arguments: (argument_list (integer)))))",
 		n.String(),

--- a/ruby/binding_test.go
+++ b/ruby/binding_test.go
@@ -1,6 +1,7 @@
 package ruby_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("puts 1"), ruby.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("puts 1"), ruby.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (call method: (identifier) arguments: (argument_list (integer))))",
 		n.String(),

--- a/rust/binding_test.go
+++ b/rust/binding_test.go
@@ -1,6 +1,7 @@
 package rust_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("mod one;"), rust.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("mod one;"), rust.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(source_file (mod_item name: (identifier)))",
 		n.String(),

--- a/scala/binding_test.go
+++ b/scala/binding_test.go
@@ -1,6 +1,7 @@
 package scala_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -15,7 +16,8 @@ const expected = `(compilation_unit (package_clause name: (package_identifier (i
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(code), scala.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(code), scala.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		expected,
 		n.String(),

--- a/svelte/binding_test.go
+++ b/svelte/binding_test.go
@@ -1,6 +1,7 @@
 package svelte_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,12 +12,13 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`<script context="module">
+	n, err := sitter.Parse(context.Background(), []byte(`<script context="module">
     let name = 'world';
 	</script>
 	<h1>Hello {name'<>{}"\''""{}}!</h1>
 	`), svelte.GetLanguage())
 
+	assert.NoError(err)
 	assert.Equal(
 		"(document (script_element (start_tag (tag_name) (attribute (attribute_name) (quoted_attribute_value (attribute_value)))) (raw_text) (end_tag (tag_name))) (text) (element (start_tag (tag_name)) (text) (expression (raw_text_expr)) (text) (end_tag (tag_name))) (text))",
 		n.String(),

--- a/toml/binding_test.go
+++ b/toml/binding_test.go
@@ -1,6 +1,7 @@
 package toml_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte(`key = "value"`), toml.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte(`key = "value"`), toml.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(document (pair (bare_key) (string)))",
 		n.String(),

--- a/typescript/tsx/binding_test.go
+++ b/typescript/tsx/binding_test.go
@@ -1,6 +1,7 @@
 package tsx_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("<foo />"), tsx.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("<foo />"), tsx.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (expression_statement (jsx_self_closing_element name: (identifier))))",
 		n.String(),

--- a/typescript/typescript/binding_test.go
+++ b/typescript/typescript/binding_test.go
@@ -1,6 +1,7 @@
 package typescript_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("let a : number = 1;"), typescript.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("let a : number = 1;"), typescript.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(program (lexical_declaration (variable_declarator name: (identifier) type: (type_annotation (predefined_type)) value: (number))))",
 		n.String(),

--- a/yaml/binding_test.go
+++ b/yaml/binding_test.go
@@ -1,6 +1,7 @@
 package yaml_test
 
 import (
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -11,7 +12,8 @@ import (
 func TestGrammar(t *testing.T) {
 	assert := assert.New(t)
 
-	n := sitter.Parse([]byte("a: 42"), yaml.GetLanguage())
+	n, err := sitter.Parse(context.Background(), []byte("a: 42"), yaml.GetLanguage())
+	assert.NoError(err)
 	assert.Equal(
 		"(stream (document (block_node (block_mapping (block_mapping_pair key: (flow_node (plain_scalar (string_scalar))) value: (flow_node (plain_scalar (integer_scalar))))))))",
 		n.String(),


### PR DESCRIPTION
- Handle context cancellation with ts_parser_set_cancellation_flag
- Return an error from Parse methods when parsing fails